### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/active_model/dynamic_errors.rb
+++ b/lib/active_model/dynamic_errors.rb
@@ -2,19 +2,20 @@ module ActiveModel
   class Errors
     # Redefine the ActiveModel::Errors::full_messages method:
     #  Returns all the full error messages in an array. 'Base' messages are handled as usual.
-    #  Non-base messages are prefixed with the attribute name as usual UNLESS 
+    #  Non-base messages are prefixed with the attribute name as usual UNLESS
     # (1) they begin with '^' in which case the attribute name is omitted.
     #     E.g. validates_acceptance_of :accepted_terms, :message => '^Please accept the terms of service'
     # (2) the message is a proc, in which case the proc is invoked on the model object.
-    #     E.g. validates_presence_of :assessment_answer_option_id, 
+    #     E.g. validates_presence_of :assessment_answer_option_id,
     #     :message => Proc.new { |aa| "#{aa.label} (#{aa.group_label}) is required" }
     #     which gives an error message like:
     #     Rate (Accuracy) is required
     def full_messages
       full_messages = []
 
-      each do |attribute, messages|
-        messages = Array.wrap(messages)
+      each do |error|
+        attribute = error.attribute
+        messages = Array.wrap(error.message)
         next if messages.empty?
 
         if attribute == :base
@@ -33,7 +34,7 @@ module ActiveModel
               full_messages << I18n.t(:"errors.dynamic_format", options.merge(:message => m.call(@base)))
             else
               full_messages << I18n.t(:"errors.format", options.merge(:message => m))
-            end            
+            end
           end
         end
       end

--- a/lib/active_model/dynamic_errors.rb
+++ b/lib/active_model/dynamic_errors.rb
@@ -11,35 +11,25 @@ module ActiveModel
     #     which gives an error message like:
     #     Rate (Accuracy) is required
     def full_messages
-      full_messages = []
-
       each do |error|
-        attribute = error.attribute
-        messages = Array.wrap(error.message)
-        next if messages.empty?
-
-        if attribute == :base
-          messages.each {|m| full_messages << m }
+        if error.attribute == :base
+          full_messages << error.message
         else
-          attr_name = attribute.to_s.gsub('.', '_').humanize
-          attr_name = @base.class.human_attribute_name(attribute, :default => attr_name)
+          attr_name = error.attribute.to_s.gsub('.', '_').humanize
+          attr_name = @base.class.human_attribute_name(error.attribute, :default => attr_name)
           options = { :default => "%{attribute} %{message}", :attribute => attr_name }
 
-          messages.each do |m|
-            if m =~ /^\^/
-              options[:default] = "%{message}"
-              full_messages << I18n.t(:"errors.dynamic_format", options.merge(:message => m[1..-1]))
-            elsif m.is_a? Proc
-              options[:default] = "%{message}"
-              full_messages << I18n.t(:"errors.dynamic_format", options.merge(:message => m.call(@base)))
-            else
-              full_messages << I18n.t(:"errors.format", options.merge(:message => m))
-            end
+          if error.message =~ /^\^/
+            options[:default] = "%{message}"
+            full_messages << I18n.t(:"errors.dynamic_format", **options.merge(:message => error.message[1..-1]))
+          elsif error.message.is_a? Proc
+            options[:default] = "%{message}"
+            full_messages << I18n.t(:"errors.dynamic_format", **options.merge(:message => error.message.call(@base)))
+          else
+            full_messages << I18n.t(:"errors.format", **options.merge(:message => error.message))
           end
         end
       end
-
-      full_messages
     end
   end
 end


### PR DESCRIPTION
Fix over 100 warning on CI over:
```
DEPRECATION WARNING: Enumerating ActiveModel::Errors as a hash has been deprecated.
In Rails 6.1, `errors` is an array of Error objects,
therefore it should be accessed by a block with a single block
parameter like this:
person.errors.each do |error|
  attribute = error.attribute
  message = error.message
end
You are passing a block expecting two parameters,
so the old hash behavior is simulated. As this is deprecated,
this will result in an ArgumentError in Rails 7.0.
 (called from full_messages at /home/travis/build/LeadDyno/leaddyno-app/vendor/bundle/ruby/2.6.0/bundler/gems/dynamic_form-3fcd00e23e84/lib/active_model/dynamic_errors.rb:16)
```

![image](https://github.com/LeadDyno/dynamic_form/assets/38764892/744b8d66-64ae-4245-981b-4063c6b86749)
https://app.travis-ci.com/github/LeadDyno/leaddyno-app/builds/270596926